### PR TITLE
Clarify consent storage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ export default function Footer() {
 ## Configuration
 No configuration needed. Automatically saves user choices under `localStorage['dorsium_consent']`.
 
+Only two boolean values are stored:
+- `analytics`
+- `marketing`
+
+These flags are kept indefinitely in `localStorage` until you clear them. No personal data is stored.
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Summary
- document what the module stores in localStorage
- explain that preferences persist until the user clears them

## Testing
- `pnpm build` *(fails: unable to reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686d1f948a1c8323a7545fd1ef1087d7