### PR TITLE
Create consent lib and update imports

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,18 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-
-const COOKIE_KEY = "dorsium_consent";
-
-export type ConsentPrefs = {
-  analytics: boolean;
-  marketing: boolean;
-};
-
-export const defaultPrefs: ConsentPrefs = {
-  analytics: false,
-  marketing: false,
-};
+import {
+  COOKIE_KEY,
+  ConsentPrefs,
+  defaultPrefs,
+} from "../lib/consent";
 
 export default function CookieConsent() {
   const [visible, setVisible] = useState(false);

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
-import { ConsentPrefs, defaultPrefs } from "../components/CookieConsent";
-
-const COOKIE_KEY = "dorsium_consent";
+import {
+  COOKIE_KEY,
+  ConsentPrefs,
+  defaultPrefs,
+} from "../lib/consent";
 
 export function useConsent() {
   const [consent, setConsent] = useState<ConsentPrefs>(defaultPrefs);

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,11 @@
+export const COOKIE_KEY = "dorsium_consent";
+
+export type ConsentPrefs = {
+  analytics: boolean;
+  marketing: boolean;
+};
+
+export const defaultPrefs: ConsentPrefs = {
+  analytics: false,
+  marketing: false,
+};


### PR DESCRIPTION
## Summary
- centralize consent types and constants in `src/lib/consent.ts`
- update `CookieConsent` and `useConsent` to import from the new module

## Testing
- `pnpm build` *(fails: Request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d2477e85c8323bfcf905682ad654b