### PR TITLE
Implement consent sync via storage events

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -11,6 +11,15 @@ export default function CookieConsent() {
   const [visible, setVisible] = useState(false);
   const [prefs, setPrefs] = useState<ConsentPrefs>(defaultPrefs);
 
+  const dispatchUpdate = (value: ConsentPrefs) => {
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: COOKIE_KEY,
+        newValue: JSON.stringify(value),
+      })
+    );
+  };
+
   useEffect(() => {
     const stored = localStorage.getItem(COOKIE_KEY);
     if (!stored) setVisible(true);
@@ -19,11 +28,13 @@ export default function CookieConsent() {
   const handleAcceptAll = () => {
     const all = { analytics: true, marketing: true };
     localStorage.setItem(COOKIE_KEY, JSON.stringify(all));
+    dispatchUpdate(all);
     setVisible(false);
   };
 
   const handleDecline = () => {
     localStorage.setItem(COOKIE_KEY, JSON.stringify(defaultPrefs));
+    dispatchUpdate(defaultPrefs);
     setVisible(false);
   };
 
@@ -33,6 +44,7 @@ export default function CookieConsent() {
 
   const handleSave = () => {
     localStorage.setItem(COOKIE_KEY, JSON.stringify(prefs));
+    dispatchUpdate(prefs);
     setVisible(false);
   };
 

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -9,19 +9,31 @@ export function useConsent() {
   const [consent, setConsent] = useState<ConsentPrefs>(defaultPrefs);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(COOKIE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
+    const readPrefs = (value: string | null) => {
+      if (!value) {
+        setConsent(defaultPrefs);
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(value);
         setConsent({
           analytics: !!parsed.analytics,
           marketing: !!parsed.marketing,
         });
+      } catch (err) {
+        console.warn("Failed to parse cookie consent prefs", err);
       }
-    } catch (err) {
-      console.warn("Failed to parse cookie consent prefs", err);
-    }
-  }, []);
+    };
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === COOKIE_KEY) readPrefs(e.newValue);
+    };
+
+    readPrefs(localStorage.getItem(COOKIE_KEY));
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  });
 
   const hasConsent = (key: keyof ConsentPrefs) => !!consent[key];
 


### PR DESCRIPTION
## Summary
- listen for `storage` events in `useConsent`
- notify other tabs about consent updates in `CookieConsent`

## Testing
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d25b5b0a48323afc8d8e2d21a1b35