### PR TITLE
Fix dependency array in useConsent hook

### DIFF
--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -33,7 +33,7 @@ export function useConsent() {
     readPrefs(localStorage.getItem(COOKIE_KEY));
     window.addEventListener("storage", handleStorage);
     return () => window.removeEventListener("storage", handleStorage);
-  });
+  }, []);
 
   const hasConsent = (key: keyof ConsentPrefs) => !!consent[key];
 


### PR DESCRIPTION
## Summary
- ensure the useEffect hook in `useConsent` only runs once by adding an empty dependency array

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686d31bfbf388323bb13e0d83e388ed1